### PR TITLE
rhsso access type public

### DIFF
--- a/plugins/modules/jcliff.py
+++ b/plugins/modules/jcliff.py
@@ -451,7 +451,7 @@ options:
 
               credential:
                 description:
-                  - The secure value for the application.
+                  - The secure value for the application. If not provided, it is setup as a public client.
                 type: str
       logging:
         description:

--- a/plugins/templates/rules/keycloak.j2
+++ b/plugins/templates/rules/keycloak.j2
@@ -10,7 +10,7 @@
             "realm" => "{{ secure_deployment['realm'] }}",  {% endif %}
             {% if 'verify_token_audience' in secure_deployment %} "verify-token-audience" => "{{ secure_deployment['verify_token_audience'] }}", {% endif %}
             {% if 'use_resource_role_mappings' in secure_deployment %} "use-resource-role-mappings" => "{{ secure_deployment['use_resource_role_mappings'] }}", {% endif %}
-            {% if 'credential' in secure_deployment %} "credential" => { "secret" => { "value" =>  "{{ secure_deployment['credential'] }}" } }, {% endif %}
+            {% if 'credential' in secure_deployment %} "credential" => { "secret" => { "value" =>  "{{ secure_deployment['credential'] }}" } }, {% else %} "public-client" => true, {% endif %}
           }
           {% endfor %}
       }


### PR DESCRIPTION
when no credential value is provided to the keycloak component, the
application is setup as a public client