### PR TITLE
Fix Molecule setup to ensure deps are installed

### DIFF
--- a/molecule/resources/requirements.yml
+++ b/molecule/resources/requirements.yml
@@ -1,5 +1,6 @@
 ---
 collections:
   - name: middleware_automation.wildfly
+  - name: middleware_automation.jcliff
   - name: community.docker
     version: ">=1.9.1"

--- a/molecule/standalone/molecule.yml
+++ b/molecule/standalone/molecule.yml
@@ -2,7 +2,7 @@
 dependency:
   name: galaxy
   options:
-    requirements-file: molecule/default/requirements.yml
+    requirements-file: molecule/resources/requirements.yml
 driver:
   name: docker
 platforms:


### PR DESCRIPTION
@guidograzioli This fix the builds on Olympus, however, I'm not too happy with the having the midlleware_automation.jcliff as a dependency for the the Molecule scenario. This was required, because Ansible could not figure out the definition of the jcliff: module. Maybe you'll have a better idea? 